### PR TITLE
feat: Add release config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/Gavive/empire/issues"
   },
   "homepage": "https://github.com/Gavive/empire#readme",
+  "release": {
+    "branches": ["official"]
+  },
   "peerDependencies": {
     "react": ">=16.0.0"
   },


### PR DESCRIPTION
This is done to specify the `release` config for semantic-release. Our `official` branch by default is not considered a release branch by semantic-release.

https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches